### PR TITLE
feat: add `resolveLockfile`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ const filename = await resolveFile('README.md', {
 })
 ```
 
+### `resolveLockFile`
+
+Find path to the lock file (`yarn.lock`, `package-lock.json`, `pnpm-lock.yaml`, `npm-shrinkwrap.json`) or throws an error.
+
+```js
+import { resolveLockFile } from 'pkg-types'
+const lockfile = await resolveFile('.')
+```
+
 ## Types
 
 **Note:** In order to make types working, you need to install `typescript` as a devDependency.

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export async function resolveTSConfig (id: string = process.cwd(), opts: Resolve
 
 const lockFiles = ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml', 'npm-shrinkwrap.json']
 
-export async function resolveLockfile(id: string = process.cwd(), opts: ResolveOptions = {}): Promise<string> {
+export async function resolveLockfile (id: string = process.cwd(), opts: ResolveOptions = {}): Promise<string> {
   const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, opts)
   const _opts = { startingFrom: resolvedPath, ...opts }
   for (const lockFile of lockFiles) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,3 +47,16 @@ export async function resolveTSConfig (id: string = process.cwd(), opts: Resolve
   const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, opts)
   return findNearestFile('tsconfig.json', { startingFrom: resolvedPath, ...opts })
 }
+
+const lockFiles = ['yarn.lock', 'package-lock.json', 'pnpm-lock.yaml', 'npm-shrinkwrap.json']
+
+export async function resolveLockfile(id: string = process.cwd(), opts: ResolveOptions = {}): Promise<string> {
+  const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, opts)
+  const _opts = { startingFrom: resolvedPath, ...opts }
+  for (const lockFile of lockFiles) {
+    try {
+      return await findNearestFile(lockFile, _opts)
+    } catch { }
+  }
+  throw new Error('No lockfile found from ' + id)
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -90,10 +90,10 @@ describe('tsconfig.json', () => {
 })
 
 describe('resolveLockfile', () => {
-  it ('works for subdir', async () => {
+  it('works for subdir', async () => {
     expect(await resolveLockfile(rFixture('./sub'))).to.equal(rFixture('./sub/yarn.lock'))
   })
-  it ('works for root dir', async () => {
+  it('works for root dir', async () => {
     expect(await resolveLockfile(rFixture('.'))).to.equal(rFixture('../..', 'pnpm-lock.yaml'))
   })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,7 +10,8 @@ import {
   writePackageJSON,
   writeTSConfig,
   TSConfig,
-  ResolveOptions
+  ResolveOptions,
+  resolveLockfile
 } from '../src'
 
 const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), 'fixture')
@@ -85,5 +86,14 @@ describe('tsconfig.json', () => {
     expectTypeOf(options.moduleResolution).toEqualTypeOf<any>()
     // TODO: type check this file.
     // expectTypeOf(options.maxNodeModuleJsDepth).toEqualTypeOf<number | undefined>()
+  })
+})
+
+describe('resolveLockfile', () => {
+  it ('works for subdir', async () => {
+    expect(await resolveLockfile(rFixture('./sub'))).to.equal(rFixture('./sub/yarn.lock'))
+  })
+  it ('works for root dir', async () => {
+    expect(await resolveLockfile(rFixture('.'))).to.equal(rFixture('../..', 'pnpm-lock.yaml'))
   })
 })


### PR DESCRIPTION
for implementing https://github.com/nuxt/framework/issues/158 and https://github.com/unjs/nitro/issues/149.

Q: We could also have a utility for detecting a version controlled root? Some monorepos don't have a lockfile in their root, e.g. just a `client` and `server` directory, or similar - but I think allowing users to configure likely covers that case.