### PR TITLE
feat: `findWorkspaceDir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const lockfile = await resolveFile('.')
 
 Try to detect workspace dir by in order:
 
-1. Farthest `.git` directory
+1. Nearest `.git` directory
 2. Farthest lockfile
 3. Farthest `package.json` file
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ import { resolveLockFile } from 'pkg-types'
 const lockfile = await resolveFile('.')
 ```
 
+### `findWorkspaceDir`
+
+Try to detect workspace dir by in order:
+
+1. Farthest `.git` directory
+2. Farthest lockfile
+3. Farthest `package.json` file
+
+If fails, throws an error.
+
+```js
+import { findWorkspaceDir } from 'pkg-types'
+const workspaceDir = await findWorkspaceDir('.')
+```
+
 ## Types
 
 **Note:** In order to make types working, you need to install `typescript` as a devDependency.

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,19 +66,19 @@ export async function findWorkspaceDir (id: string = process.cwd(), opts: Resolv
   const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, opts)
   const _opts = { startingFrom: resolvedPath, reverse: true, ...opts }
 
-  // Lookup for .git/config
+  // Lookdown for .git/config
   try {
     const r = await findFile('.git/config', _opts)
     return resolve(r, '../..')
   } catch { }
 
-  // Lookup for lockfile
+  // Lookdown for lockfile
   try {
     const r = await resolveLockfile(resolvedPath, _opts)
     return dirname(r)
   } catch { }
 
-  // Lookup for package.json
+  // Lookdown for package.json
   try {
     const r = await findFile(resolvedPath, _opts)
     return dirname(r)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { promises as fsp } from 'fs'
+import { dirname, resolve } from 'path'
 import { ResolveOptions as _ResolveOptions, resolvePath } from 'mlly'
 import { isAbsolute } from 'pathe'
 import { findFile, FindFileOptions, findNearestFile } from './utils'
 import type { PackageJson, TSConfig } from './types'
-import { dirname, resolve } from 'path'
 
 export * from './types'
 export * from './utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,17 +64,17 @@ export async function resolveLockfile (id: string = process.cwd(), opts: Resolve
 
 export async function findWorkspaceDir (id: string = process.cwd(), opts: ResolveOptions = {}): Promise<string> {
   const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, opts)
-  const _opts = { startingFrom: resolvedPath, reverse: true, ...opts }
+  const _opts = { startingFrom: resolvedPath, ...opts }
 
-  // Lookdown for .git/config
+  // Lookup for .git/config
   try {
-    const r = await findFile('.git/config', _opts)
+    const r = await findNearestFile('.git/config', _opts)
     return resolve(r, '../..')
   } catch { }
 
   // Lookdown for lockfile
   try {
-    const r = await resolveLockfile(resolvedPath, _opts)
+    const r = await resolveLockfile(resolvedPath, { ..._opts, reverse: true })
     return dirname(r)
   } catch { }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export async function findWorkspaceDir (id: string = process.cwd(), opts: Resolv
     return dirname(r)
   } catch { }
 
-  // Try to find a package.json
+  // Lookup for package.json
   try {
     const r = await findFile(resolvedPath, _opts)
     return dirname(r)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,7 +61,7 @@ export async function findFile (filename: string, _options: FindFileOptions = {}
       if (await options.test(filePath)) { return filePath }
     }
   } else {
-    for (let i = root + 1; i < segments.length; i++) {
+    for (let i = root + 1; i <= segments.length; i++) {
       const filePath = join(...segments.slice(0, i), filename)
       if (await options.test(filePath)) { return filePath }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -100,7 +100,10 @@ describe('resolveLockfile', () => {
 })
 
 describe('findWorkspaceDir', () => {
-  it('works for subdir', async () => {
+  it('works', async () => {
     expect(await findWorkspaceDir(rFixture('./sub'))).to.equal(rFixture('../..'))
+    expect(await findWorkspaceDir(rFixture('.'))).to.equal(rFixture('../..'))
+    expect(await findWorkspaceDir(rFixture('..'))).to.equal(rFixture('../..'))
+    expect(await findWorkspaceDir(rFixture('../..'))).to.equal(rFixture('../..'))
   })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,7 +11,8 @@ import {
   writeTSConfig,
   TSConfig,
   ResolveOptions,
-  resolveLockfile
+  resolveLockfile,
+  findWorkspaceDir
 } from '../src'
 
 const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), 'fixture')
@@ -95,5 +96,11 @@ describe('resolveLockfile', () => {
   })
   it('works for root dir', async () => {
     expect(await resolveLockfile(rFixture('.'))).to.equal(rFixture('../..', 'pnpm-lock.yaml'))
+  })
+})
+
+describe('findWorkspaceDir', () => {
+  it('works for subdir', async () => {
+    expect(await findWorkspaceDir(rFixture('./sub'))).to.equal(rFixture('../..'))
   })
 })


### PR DESCRIPTION
Based on https://github.com/unjs/pkg-types/pull/14 and https://github.com/unjs/pkg-types/pull/32

Adding a basic utility to detect workspace.

1. Farthest `.git` directory
2. Farthest lockfile
3. Farthest `package.json` file
