### PR TITLE
fix: add `exports.types` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "./dist/index.cjs",
   "sideEffects": false,
   "exports": {
+    "types": "./dist/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
Fixes the following TypeScript error when `moduleResolution` is set to `"nodenext"` or `"bundler"`:

```
Could not find a declaration file for module 'pkg-types'. '/.../node_modules/.pnpm/pkg-types@1.0.2/node_modules/pkg-types/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/.../node_modules/pkg-types/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'pkg-types' library may need to update its package.json or typings.
```

See https://nodejs.org/api/packages.html#community-conditions-definitions