### PR TITLE
feat: `WriteOptions` to control indent & line breaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "eslint --ext .ts,.js,.mjs,.cjs . && prettier -c src test",
     "lint:fix": "eslint --fix --ext .ts,.js,.mjs,.cjs . && prettier -w src test",
     "test": "vitest run --coverage",
-    "test:types": "tsc --noEmit --module esnext --skipLibCheck --moduleResolution node ./test/*.test.ts"
+    "test:types": "tsc --noEmit --module esnext --target esnext --skipLibCheck --moduleResolution node ./test/*.test.ts"
   },
   "dependencies": {
     "jsonc-parser": "^3.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,21 +13,26 @@ export type ReadOptions = {
 };
 
 export type WriteOptions = {
-  indent?: number | 'tab';
-  eol?: 'LF' | 'CRLF';
+  indent?: number | "tab";
+  eol?: "LF" | "CRLF";
   eolFinal?: boolean;
 };
 
-const EOL_CRLF = '\r\n';
-const EOL_LF = '\n';
+const EOL_CRLF = "\r\n";
+const EOL_LF = "\n";
 
 function stringifyJSON(value: any, options: WriteOptions = {}) {
-  const eol = (options.eol === 'CRLF') ? EOL_CRLF : EOL_LF;
-  const jstr = JSON.stringify(value, undefined,
-    (options.indent === 'tab') ? '\t' : (options.indent ?? 2));
+  const eol = options.eol === "CRLF" ? EOL_CRLF : EOL_LF;
+  const jstr = JSON.stringify(
+    value,
+    undefined,
+    options.indent === "tab" ? "\t" : options.indent ?? 2
+  );
 
-  return (eol !== EOL_LF ? jstr.replaceAll(EOL_LF, eol) : jstr) +
-    ((options.eolFinal ?? jstr.includes(EOL_LF)) ? eol : '');
+  return (
+    (eol !== EOL_LF ? jstr.replaceAll(EOL_LF, eol) : jstr) +
+    (options.eolFinal ?? jstr.includes(EOL_LF) ? eol : "")
+  );
 }
 
 export function definePackageJSON(package_: PackageJson): PackageJson {
@@ -50,6 +55,7 @@ export async function readPackageJSON(
       ? options.cache
       : FileCache;
   if (options.cache && cache.has(resolvedPath)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return cache.get(resolvedPath)!;
   }
   const blob = await fsp.readFile(resolvedPath, "utf8");
@@ -76,6 +82,7 @@ export async function readTSConfig(
       ? options.cache
       : FileCache;
   if (options.cache && cache.has(resolvedPath)) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return cache.get(resolvedPath)!;
   }
   const blob = await fsp.readFile(resolvedPath, "utf8");

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,24 @@ export type ReadOptions = {
   cache?: boolean | Map<string, Record<string, any>>;
 };
 
+export type WriteOptions = {
+  indent?: number | 'tab';
+  eol?: 'LF' | 'CRLF';
+  eolFinal?: boolean;
+};
+
+const EOL_CRLF = '\r\n';
+const EOL_LF = '\n';
+
+function stringifyJSON(value: any, options: WriteOptions = {}) {
+  const eol = (options.eol === 'CRLF') ? EOL_CRLF : EOL_LF;
+  const jstr = JSON.stringify(value, undefined,
+    (options.indent === 'tab') ? '\t' : (options.indent ?? 2));
+
+  return (eol !== EOL_LF ? jstr.replaceAll(EOL_LF, eol) : jstr) +
+    ((options.eolFinal ?? jstr.includes(EOL_LF)) ? eol : '');
+}
+
 export function definePackageJSON(package_: PackageJson): PackageJson {
   return package_;
 }
@@ -42,9 +60,10 @@ export async function readPackageJSON(
 
 export async function writePackageJSON(
   path: string,
-  package_: PackageJson
+  package_: PackageJson,
+  options?: WriteOptions
 ): Promise<void> {
-  await fsp.writeFile(path, JSON.stringify(package_, undefined, 2));
+  await fsp.writeFile(path, stringifyJSON(package_, options));
 }
 
 export async function readTSConfig(
@@ -68,9 +87,10 @@ export async function readTSConfig(
 
 export async function writeTSConfig(
   path: string,
-  tsconfig: TSConfig
+  tsconfig: TSConfig,
+  options?: WriteOptions
 ): Promise<void> {
-  await fsp.writeFile(path, JSON.stringify(tsconfig, undefined, 2));
+  await fsp.writeFile(path, stringifyJSON(tsconfig, options));
 }
 
 export async function resolvePackageJSON(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
+    "lib": ["ES2021"],
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "outDir": "dist",


### PR DESCRIPTION
Added `options` parameter to `writePackageJSON` and `writeTSConfig` to control indentation & line breaks of the generated file:

- `indent` (default `2`): `'tab'` or `number` to control file indentation style
- `eol` (default `'LF'`): `'LF'` or `'CRLF'` to control how line breaks are represented
- `eolFinal` (default `true` _if the json contains line breaks_): when `true` it ensure file ends with a newline
