### PR TITLE
docs: add missing jsdocs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export * from "./utils";
 
 /**
  * Represents the options for resolving paths with additional file finding capabilities.
- * Extends {@link _ResolveOptions} and {@link FindFileOptions}.
  */
 export type ResolveOptions = _ResolveOptions & FindFileOptions;
 
@@ -18,16 +17,16 @@ export type ResolveOptions = _ResolveOptions & FindFileOptions;
  */
 export type ReadOptions = {
   /**
-   * Specifies whether the read results should be cached. Can be a boolean or a map to hold the cached data.
-   * @optional
+   * Specifies whether the read results should be cached.
+   * Can be a boolean or a map to hold the cached data.
    */
   cache?: boolean | Map<string, Record<string, any>>;
 };
 
 /**
  * Defines a PackageJson structure.
- * @param package_ - The package.json content as an object. See {@link PackageJson}.
- * @returns the same package.json object.
+ * @param package_ - The `package.json` content as an object. See {@link PackageJson}.
+ * @returns the same `package.json` object.
  */
 export function definePackageJSON(package_: PackageJson): PackageJson {
   return package_;
@@ -35,8 +34,8 @@ export function definePackageJSON(package_: PackageJson): PackageJson {
 
 /**
  * Defines a TSConfig structure.
- * @param tsconfig - The contents of tsconfig.json as an object. See {@link TSConfig}.
- * @returns the same tsconfig.json object.
+ * @param tsconfig - The contents of `tsconfig.json` as an object. See {@link TSConfig}.
+ * @returns the same `tsconfig.json` object.
  */
 export function defineTSConfig(tsconfig: TSConfig): TSConfig {
   return tsconfig;
@@ -45,10 +44,10 @@ export function defineTSConfig(tsconfig: TSConfig): TSConfig {
 const FileCache = new Map<string, Record<string, any>>();
 
 /**
- * Asynchronously reads a package.json file.
+ * Asynchronously reads a `package.json` file.
  * @param id - The path identifier for the package.json, defaults to the current working directory.
  * @param options - The options for resolving and reading the file. See {@link ResolveOptions}.
- * @returns a promise resolving to the parsed package.json object.
+ * @returns a promise resolving to the parsed `package.json` object.
  */
 export async function readPackageJSON(
   id?: string,
@@ -69,9 +68,9 @@ export async function readPackageJSON(
 }
 
 /**
- * Asynchronously writes data to a package.json file.
- * @param path - The path to the file where the package.json is written.
- * @param package_ - The package.json object to write. See {@link PackageJson}.
+ * Asynchronously writes data to a `package.json` file.
+ * @param path - The path to the file where the `package.json` is written.
+ * @param package_ - The `package.json` object to write. See {@link PackageJson}.
  */
 export async function writePackageJSON(
   path: string,
@@ -81,10 +80,10 @@ export async function writePackageJSON(
 }
 
 /**
- * Asynchronously reads a tsconfig.json file.
- * @param id - The path to the tsconfig.json file, defaults to the current working directory.
+ * Asynchronously reads a `tsconfig.json` file.
+ * @param id - The path to the `tsconfig.json` file, defaults to the current working directory.
  * @param options - The options for resolving and reading the file. See {@link ResolveOptions}.
- * @returns a promise resolving to the parsed tsconfig.json object.
+ * @returns a promise resolving to the parsed `tsconfig.json` object.
  */
 export async function readTSConfig(
   id?: string,
@@ -106,9 +105,9 @@ export async function readTSConfig(
 }
 
 /**
- * Asynchronously writes data to a tsconfig.json file.
- * @param path - The path to the file where the tsconfig.json is written.
- * @param tsconfig - The tsconfig.json object to write. See {@link TSConfig}.
+ * Asynchronously writes data to a `tsconfig.json` file.
+ * @param path - The path to the file where the `tsconfig.json` is written.
+ * @param tsconfig - The `tsconfig.json` object to write. See {@link TSConfig}.
  */
 export async function writeTSConfig(
   path: string,
@@ -118,10 +117,10 @@ export async function writeTSConfig(
 }
 
 /**
- * Resolves the path to the nearest package.json file from a given directory.
+ * Resolves the path to the nearest `package.json` file from a given directory.
  * @param id - The base path for the search, defaults to the current working directory.
  * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
- * @returns A promise resolving to the path of the nearest package.json file.
+ * @returns A promise resolving to the path of the nearest `package.json` file.
  */
 export async function resolvePackageJSON(
   id: string = process.cwd(),
@@ -135,10 +134,10 @@ export async function resolvePackageJSON(
 }
 
 /**
- * Resolves the path to the nearest tsconfig.json file from a given directory.
+ * Resolves the path to the nearest `tsconfig.json` file from a given directory.
  * @param id - The base path for the search, defaults to the current working directory.
  * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
- * @returns A promise resolving to the path of the nearest tsconfig.json file.
+ * @returns A promise resolving to the path of the nearest `tsconfig.json` file.
  */
 export async function resolveTSConfig(
   id: string = process.cwd(),
@@ -160,10 +159,10 @@ const lockFiles = [
 ];
 
 /**
- * Resolves the path to the nearest tsconfig.json file from a given directory.
+ * Resolves the path to the nearest `tsconfig.json` file from a given directory.
  * @param id - The base path for the search, defaults to the current working directory.
  * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
- * @returns A promise resolving to the path of the nearest tsconfig.json file.
+ * @returns A promise resolving to the path of the nearest `tsconfig.json` file.
  */
 export async function resolveLockfile(
   id: string = process.cwd(),
@@ -182,7 +181,7 @@ export async function resolveLockfile(
 }
 
 /**
- * Detects the workspace directory based on common project markers (.git, lockfiles, package.json).
+ * Detects the workspace directory based on common project markers (`.git`, lockfiles, `package.json`).
  * Throws an error if the workspace root cannot be detected.
  * @param id - The base path to search, defaults to the current working directory.
  * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,21 +7,49 @@ import type { PackageJson, TSConfig } from "./types";
 export * from "./types";
 export * from "./utils";
 
+/**
+ * Represents the options for resolving paths with additional file finding capabilities.
+ * Extends {@link _ResolveOptions} and {@link FindFileOptions}.
+ */
 export type ResolveOptions = _ResolveOptions & FindFileOptions;
+
+/**
+ * Options for reading files with optional caching.
+ */
 export type ReadOptions = {
+  /**
+   * Specifies whether the read results should be cached. Can be a boolean or a map to hold the cached data.
+   * @optional
+   */
   cache?: boolean | Map<string, Record<string, any>>;
 };
 
+/**
+ * Defines a PackageJson structure.
+ * @param package_ - The package.json content as an object. See {@link PackageJson}.
+ * @returns the same package.json object.
+ */
 export function definePackageJSON(package_: PackageJson): PackageJson {
   return package_;
 }
 
+/**
+ * Defines a TSConfig structure.
+ * @param tsconfig - The contents of tsconfig.json as an object. See {@link TSConfig}.
+ * @returns the same tsconfig.json object.
+ */
 export function defineTSConfig(tsconfig: TSConfig): TSConfig {
   return tsconfig;
 }
 
 const FileCache = new Map<string, Record<string, any>>();
 
+/**
+ * Asynchronously reads a package.json file.
+ * @param id - The path identifier for the package.json, defaults to the current working directory.
+ * @param options - The options for resolving and reading the file. See {@link ResolveOptions}.
+ * @returns a promise resolving to the parsed package.json object.
+ */
 export async function readPackageJSON(
   id?: string,
   options: ResolveOptions & ReadOptions = {}
@@ -40,6 +68,11 @@ export async function readPackageJSON(
   return parsed;
 }
 
+/**
+ * Asynchronously writes data to a package.json file.
+ * @param path - The path to the file where the package.json is written.
+ * @param package_ - The package.json object to write. See {@link PackageJson}.
+ */
 export async function writePackageJSON(
   path: string,
   package_: PackageJson
@@ -47,6 +80,12 @@ export async function writePackageJSON(
   await fsp.writeFile(path, JSON.stringify(package_, undefined, 2));
 }
 
+/**
+ * Asynchronously reads a tsconfig.json file.
+ * @param id - The path to the tsconfig.json file, defaults to the current working directory.
+ * @param options - The options for resolving and reading the file. See {@link ResolveOptions}.
+ * @returns a promise resolving to the parsed tsconfig.json object.
+ */
 export async function readTSConfig(
   id?: string,
   options: ResolveOptions & ReadOptions = {}
@@ -66,6 +105,11 @@ export async function readTSConfig(
   return parsed;
 }
 
+/**
+ * Asynchronously writes data to a tsconfig.json file.
+ * @param path - The path to the file where the tsconfig.json is written.
+ * @param tsconfig - The tsconfig.json object to write. See {@link TSConfig}.
+ */
 export async function writeTSConfig(
   path: string,
   tsconfig: TSConfig
@@ -73,6 +117,12 @@ export async function writeTSConfig(
   await fsp.writeFile(path, JSON.stringify(tsconfig, undefined, 2));
 }
 
+/**
+ * Resolves the path to the nearest package.json file from a given directory.
+ * @param id - The base path for the search, defaults to the current working directory.
+ * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
+ * @returns A promise resolving to the path of the nearest package.json file.
+ */
 export async function resolvePackageJSON(
   id: string = process.cwd(),
   options: ResolveOptions = {}
@@ -84,6 +134,12 @@ export async function resolvePackageJSON(
   });
 }
 
+/**
+ * Resolves the path to the nearest tsconfig.json file from a given directory.
+ * @param id - The base path for the search, defaults to the current working directory.
+ * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
+ * @returns A promise resolving to the path of the nearest tsconfig.json file.
+ */
 export async function resolveTSConfig(
   id: string = process.cwd(),
   options: ResolveOptions = {}
@@ -103,6 +159,12 @@ const lockFiles = [
   "bun.lockb",
 ];
 
+/**
+ * Resolves the path to the nearest tsconfig.json file from a given directory.
+ * @param id - The base path for the search, defaults to the current working directory.
+ * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
+ * @returns A promise resolving to the path of the nearest tsconfig.json file.
+ */
 export async function resolveLockfile(
   id: string = process.cwd(),
   options: ResolveOptions = {}
@@ -117,6 +179,13 @@ export async function resolveLockfile(
   throw new Error("No lockfile found from " + id);
 }
 
+/**
+ * Detects the workspace directory based on common project markers (.git, lockfiles, package.json).
+ * Throws an error if the workspace root cannot be detected.
+ * @param id - The base path to search, defaults to the current working directory.
+ * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
+ * @returns a promise resolving to the path of the detected workspace directory.
+ */
 export async function findWorkspaceDir(
   id: string = process.cwd(),
   options: ResolveOptions = {}

--- a/src/types/packagejson.ts
+++ b/src/types/packagejson.ts
@@ -121,6 +121,9 @@ export interface PackageJson {
    * TypeScript typings, typically ending by .d.ts
    */
   types?: string;
+  /**
+   * TypeScript typings for the main entry-point, typically ending by .d.ts
+   */
   typings?: string;
   /**
    * Non-Standard Node.js alternate entry-point to main.
@@ -154,6 +157,9 @@ export interface PackageJson {
         "import" | "require" | "." | "node" | "browser" | string,
         string | Record<"import" | "require" | string, string>
       >;
+  /**
+   * The optional engines field is used to specify the versions of npm and node that your stuff works on.
+   */
   workspaces?: string[];
   [key: string]: any;
 }

--- a/src/types/packagejson.ts
+++ b/src/types/packagejson.ts
@@ -118,11 +118,11 @@ export interface PackageJson {
    */
   peerDependencies?: Record<string, string>;
   /**
-   * TypeScript typings, typically ending by .d.ts
+   * TypeScript typings, typically ending by `.d.ts`.
    */
   types?: string;
   /**
-   * TypeScript typings for the main entry-point, typically ending by .d.ts
+   * This field is synonymous with `types`.
    */
   typings?: string;
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,13 @@ const defaultFindOptions: Required<FindFileOptions> = {
   },
 };
 
+/**
+ * Asynchronously finds a file by name, starting from the specified directory and traversing up (or down if reverse).
+ * @param filename - The name of the file to find.
+ * @param _options - Options to customise the search behaviour.
+ * @returns a promise that resolves to the path of the file found.
+ * @throws Will throw an error if the file cannot be found.
+ */
 export async function findFile(
   filename: string,
   _options: FindFileOptions = {}
@@ -84,6 +91,13 @@ export async function findFile(
   );
 }
 
+/**
+ * Asynchronously finds the next file with the given name, starting in the given directory and moving up.
+ * Alias for findFile without reversing the search.
+ * @param filename - The name of the file to find.
+ * @param _options - Options to customise the search behaviour.
+ * @returns A promise that resolves to the path of the next file found.
+ */
 export function findNearestFile(
   filename: string,
   _options: FindFileOptions = {}
@@ -91,6 +105,13 @@ export function findNearestFile(
   return findFile(filename, _options);
 }
 
+/**
+ * Asynchronously finds the furthest file with the given name, starting from the root directory and moving downwards.
+ * This is essentially the reverse of `findNearestFile'.
+ * @param filename - The name of the file to find.
+ * @param _options - Options to customise the search behaviour, with reverse set to true.
+ * @returns A promise that resolves to the path of the farthest file found.
+ */
 export function findFarthestFile(
   filename: string,
   _options: FindFileOptions = {}


### PR DESCRIPTION
Added JSDocs to exported functions

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

> Any feedback is welcomed! 🙌

