### PR TITLE
feat: auto detect and preserve format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+test/fixture/tsconfig.json

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:types": "tsc --noEmit --module esnext --skipLibCheck --moduleResolution node ./test/*.test.ts"
   },
   "dependencies": {
-    "confbox": "^0.1.6",
+    "confbox": "^0.1.7",
     "mlly": "^1.6.1",
     "pathe": "^1.1.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       confbox:
-        specifier: ^0.1.6
-        version: 0.1.6
+        specifier: ^0.1.7
+        version: 0.1.7
       mlly:
         specifier: ^1.6.1
         version: 1.6.1
@@ -1029,8 +1029,8 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  confbox@0.1.6:
-    resolution: {integrity: sha512-ONc4FUXne/1UBN1EuxvQ5rAjjAbo+N4IxrxWI8bzGHbd1PyrFlI/E3G23/yoJZDFBaFFxPGfI0EOq0fa4dgX7A==}
+  confbox@0.1.7:
+    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
 
   consola@3.2.3:
     resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
@@ -3308,7 +3308,7 @@ snapshots:
   c12@1.10.0:
     dependencies:
       chokidar: 3.6.0
-      confbox: 0.1.6
+      confbox: 0.1.7
       defu: 6.1.4
       dotenv: 16.4.5
       giget: 1.2.3
@@ -3430,7 +3430,7 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  confbox@0.1.6: {}
+  confbox@0.1.7: {}
 
   consola@3.2.3: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { dirname, resolve, isAbsolute } from "pathe";
 import { ResolveOptions as _ResolveOptions, resolvePath } from "mlly";
 import { findFile, FindFileOptions, findNearestFile } from "./utils";
 import type { PackageJson, TSConfig } from "./types";
-import { parseJSONC } from "confbox";
+import { parseJSONC, parseJSON, stringifyJSON, stringifyJSONC } from "confbox";
 
 export * from "./types";
 export * from "./utils";
@@ -63,7 +63,7 @@ export async function readPackageJSON(
     return cache.get(resolvedPath)!;
   }
   const blob = await fsp.readFile(resolvedPath, "utf8");
-  const parsed = JSON.parse(blob) as PackageJson;
+  const parsed = parseJSON(blob) as PackageJson;
   cache.set(resolvedPath, parsed);
   return parsed;
 }
@@ -77,7 +77,7 @@ export async function writePackageJSON(
   path: string,
   package_: PackageJson,
 ): Promise<void> {
-  await fsp.writeFile(path, JSON.stringify(package_, undefined, 2));
+  await fsp.writeFile(path, stringifyJSON(package_));
 }
 
 /**
@@ -113,7 +113,7 @@ export async function writeTSConfig(
   path: string,
   tsconfig: TSConfig,
 ): Promise<void> {
-  await fsp.writeFile(path, JSON.stringify(tsconfig, undefined, 2));
+  await fsp.writeFile(path, stringifyJSONC(tsconfig));
 }
 
 /**

--- a/test/fixture/tsconfig.json
+++ b/test/fixture/tsconfig.json
@@ -1,6 +1,5 @@
 {
-  // Comment
-  "compilerOptions": {
+  "compilerOptions": { // Comment
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
@@ -8,7 +7,11 @@
     "outDir": "dist",
     "strict": true,
     "declaration": true,
-    "types": ["node"]
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,6 +14,7 @@ import {
   resolveLockfile,
   findWorkspaceDir,
 } from "../src";
+import { readFile } from "node:fs/promises";
 
 const fixtureDir = resolve(dirname(fileURLToPath(import.meta.url)), "fixture");
 
@@ -90,6 +91,19 @@ describe("package.json", () => {
       "string",
     );
   });
+
+  it("styles are preserved", async () => {
+    const originalContent = await readFile(rFixture("package.json"), "utf8");
+    await writePackageJSON(
+      rFixture("package.json") + ".tmp",
+      await readPackageJSON(rFixture("package.json")),
+    );
+    const newContent = await readFile(
+      rFixture("package.json") + ".tmp",
+      "utf8",
+    );
+    expect(newContent).toBe(originalContent);
+  });
 });
 
 describe("tsconfig.json", () => {
@@ -111,6 +125,19 @@ describe("tsconfig.json", () => {
     expectTypeOf(options.moduleResolution).toEqualTypeOf<any>();
     // TODO: type check this file.
     // expectTypeOf(options.maxNodeModuleJsDepth).toEqualTypeOf<number | undefined>()
+  });
+
+  it("styles are preserved", async () => {
+    const originalContent = await readFile(rFixture("tsconfig.json"), "utf8");
+    await writeTSConfig(
+      rFixture("tsconfig.json") + ".tmp",
+      await readTSConfig(rFixture("tsconfig.json")),
+    );
+    const newContent = await readFile(
+      rFixture("tsconfig.json") + ".tmp",
+      "utf8",
+    );
+    expect(newContent).toBe(originalContent.replace(/\s*\/\/\s*.+/g, ""));
   });
 });
 


### PR DESCRIPTION
previous efforts: #142, #125, #113 (thanks @iijaachok, @Waleed-KH, @aa900031 ❤️ )

resolves #132

This PR uses [confbox](https://github.com/unjs/confbox/tree/main) utils to parse and serialize package.json/tsconfig. confbox automatically detects and preserves indentation and start/end whitespace. 