### PR TITLE
feat: try to parse `package.json` as jsonc

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-dist
-node_modules
-coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 test/fixture/tsconfig.json
+test/fixture/jsonc/package.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import unjs from 'eslint-config-unjs';
 export default unjs(
   {
     ignores: [
+      "test/fixture/jsonc/package.json"
     ]
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,12 @@ export async function readPackageJSON(
     return cache.get(resolvedPath)!;
   }
   const blob = await fsp.readFile(resolvedPath, "utf8");
-  const parsed = parseJSON(blob) as PackageJson;
+  let parsed: PackageJson;
+  try {
+    parsed = parseJSON(blob) as PackageJson;
+  } catch {
+    parsed = parseJSONC(blob) as PackageJson;
+  }
   cache.set(resolvedPath, parsed);
   return parsed;
 }

--- a/test/fixture/jsonc/package.json
+++ b/test/fixture/jsonc/package.json
@@ -1,0 +1,5 @@
+{
+  // This is a comment!
+  "name": "foo",
+  "version": "1.0.0",
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -73,6 +73,11 @@ describe("package.json", () => {
     expect(package_.name).to.equal("foo");
   });
 
+  it("read package.json (jsonc)", async () => {
+    const package_ = await readPackageJSON(rFixture("jsonc/package.json"));
+    expect(package_.name).to.equal("foo");
+  });
+
   it("write package.json", async () => {
     await writePackageJSON(rFixture("package.json.tmp"), { version: "1.0.0" });
     expect(


### PR DESCRIPTION
Context: Bun is going to allow `package.json` with jsonc format (comments and trailing) [tweet](https://twitter.com/jarredsumner/status/1779997854075171184)

Preparing ecosystem takes time and it will be a chicken or egg problem unless we support foundation for adoption.

This PR adds support for `package.json` with jsonc format using [confbox](https://confbox.unjs.io) utils.

---

Implementation notes:

- Using fallback approach to avoid any perf penalties. jsonc parser will be only used if parsing as json fails so we don't introduce perf penalties.
- json5 is not used since is not adopted in toolings at least and is way slower (20x vs 2x)
- when writing package.json, trailing and comments will be dropped

