### PR TITLE
fix: check for all lockfiles before ascending directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 *.tmp
 .nyc*
 coverage
+.DS_Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,10 +164,10 @@ const lockFiles = [
 ];
 
 /**
- * Resolves the path to the nearest `lockfiles` from a given directory.
+ * Resolves the path to the nearest lockfile from a given directory.
  * @param id - The base path for the search, defaults to the current working directory.
  * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
- * @returns A promise resolving to the path of the nearest `lockfiles`.
+ * @returns A promise resolving to the path of the nearest lockfile.
  */
 export async function resolveLockfile(
   id: string = process.cwd(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,10 +164,10 @@ const lockFiles = [
 ];
 
 /**
- * Resolves the path to the nearest `tsconfig.json` file from a given directory.
+ * Resolves the path to the nearest `lockfiles` from a given directory.
  * @param id - The base path for the search, defaults to the current working directory.
  * @param options - Options to modify the search behaviour. See {@link ResolveOptions}.
- * @returns A promise resolving to the path of the nearest `tsconfig.json` file.
+ * @returns A promise resolving to the path of the nearest `lockfiles`.
  */
 export async function resolveLockfile(
   id: string = process.cwd(),
@@ -175,13 +175,13 @@ export async function resolveLockfile(
 ): Promise<string> {
   const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, options);
   const _options = { startingFrom: resolvedPath, ...options };
-  for (const lockFile of lockFiles) {
-    try {
-      return await findNearestFile(lockFile, _options);
-    } catch {
-      // Ignore
-    }
+
+  try {
+    return await findNearestFile(lockFiles, _options);
+  } catch {
+    // Ignore
   }
+
   throw new Error("No lockfile found from " + id);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,9 +53,10 @@ const defaultFindOptions: Required<FindFileOptions> = {
  * @throws Will throw an error if the file cannot be found.
  */
 export async function findFile(
-  filename: string,
+  filename: string | string[],
   _options: FindFileOptions = {},
 ): Promise<string> {
+  const filenames = Array.isArray(filename) ? filename : [filename];
   const options = { ...defaultFindOptions, ..._options };
   const basePath = resolve(options.startingFrom);
   const leadingSlash = basePath[0] === "/";
@@ -74,16 +75,20 @@ export async function findFile(
 
   if (options.reverse) {
     for (let index = root + 1; index <= segments.length; index++) {
-      const filePath = join(...segments.slice(0, index), filename);
-      if (await options.test(filePath)) {
-        return filePath;
+      for (const filename of filenames) {
+        const filePath = join(...segments.slice(0, index), filename);
+        if (await options.test(filePath)) {
+          return filePath;
+        }
       }
     }
   } else {
     for (let index = segments.length; index > root; index--) {
-      const filePath = join(...segments.slice(0, index), filename);
-      if (await options.test(filePath)) {
-        return filePath;
+      for (const filename of filenames) {
+        const filePath = join(...segments.slice(0, index), filename);
+        if (await options.test(filePath)) {
+          return filePath;
+        }
       }
     }
   }
@@ -101,7 +106,7 @@ export async function findFile(
  * @returns A promise that resolves to the path of the next file found.
  */
 export function findNearestFile(
-  filename: string,
+  filename: string | string[],
   _options: FindFileOptions = {},
 ): Promise<string> {
   return findFile(filename, _options);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When I use `findWorkspaceDir` without `git`, it would look for lockfile by `resolveLockfile`. Finding all format of the lockfile before traverse directory would be better.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
