### PR TITLE
fix: fix types for `PackageJson` exports

### DIFF
--- a/src/types/packagejson.ts
+++ b/src/types/packagejson.ts
@@ -9,21 +9,21 @@ export type PackageJsonPerson =
       url?: string;
     };
 
-export type PackageJsonExports =
-  | string
-  | string[]
-  | {
-      [P in
-        | "."
-        | "import"
-        | "require"
-        | "types"
-        | "node"
-        | "browser"
-        | "default"
-        // eslint-disable-next-line @typescript-eslint/ban-types
-        | (string & {})]: PackageJsonExports;
-    };
+type PackageJsonExportKey =
+  | "."
+  | "import"
+  | "require"
+  | "types"
+  | "node"
+  | "browser"
+  | "default"
+  | (string & {}); // eslint-disable-line @typescript-eslint/ban-types
+
+type PackageJsonExportsObject = {
+  [P in PackageJsonExportKey]?: string | PackageJsonExportsObject;
+};
+
+export type PackageJsonExports = string | PackageJsonExportsObject;
 
 export interface PackageJson {
   /**

--- a/src/types/packagejson.ts
+++ b/src/types/packagejson.ts
@@ -20,7 +20,10 @@ type PackageJsonExportKey =
   | (string & {}); // eslint-disable-line @typescript-eslint/ban-types
 
 type PackageJsonExportsObject = {
-  [P in PackageJsonExportKey]?: string | PackageJsonExportsObject;
+  [P in PackageJsonExportKey]?:
+    | string
+    | PackageJsonExportsObject
+    | Array<string | PackageJsonExportsObject>;
 };
 
 export type PackageJsonExports = string | PackageJsonExportsObject;

--- a/src/types/packagejson.ts
+++ b/src/types/packagejson.ts
@@ -26,7 +26,10 @@ type PackageJsonExportsObject = {
     | Array<string | PackageJsonExportsObject>;
 };
 
-export type PackageJsonExports = string | PackageJsonExportsObject;
+export type PackageJsonExports =
+  | string
+  | PackageJsonExportsObject
+  | Array<string | PackageJsonExportsObject>;
 
 export interface PackageJson {
   /**

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -7,6 +7,68 @@ test("types", () => {
     {},
     { name: "foo" },
     { version: "1.0.0" },
+    // Exports field
     { exports: "./index.mjs" },
+    { exports: {} },
+    {
+      exports: {
+        ".": "./index.mjs",
+      },
+    },
+    {
+      exports: {
+        ".": {
+          import: {
+            types: "./dist/vue.d.mts",
+            node: "./index.mjs",
+            default: "./dist/vue.runtime.esm-bundler.js",
+          },
+          require: {
+            types: "./dist/vue.d.ts",
+            node: {
+              production: "./dist/vue.cjs.prod.js",
+              development: "./dist/vue.cjs.js",
+              default: "./index.js",
+            },
+            default: "./index.js",
+          },
+        },
+        "./server-renderer": {
+          import: {
+            types: "./server-renderer/index.d.mts",
+            default: "./server-renderer/index.mjs",
+          },
+          require: {
+            types: "./server-renderer/index.d.ts",
+            default: "./server-renderer/index.js",
+          },
+        },
+        "./compiler-sfc": {
+          import: {
+            types: "./compiler-sfc/index.d.mts",
+            browser: "./compiler-sfc/index.browser.mjs",
+            default: "./compiler-sfc/index.mjs",
+          },
+          require: {
+            types: "./compiler-sfc/index.d.ts",
+            browser: "./compiler-sfc/index.browser.js",
+            default: "./compiler-sfc/index.js",
+          },
+        },
+        "./jsx-runtime": {
+          types: "./jsx-runtime/index.d.ts",
+          import: "./jsx-runtime/index.mjs",
+          require: "./jsx-runtime/index.js",
+        },
+        "./jsx-dev-runtime": {
+          types: "./jsx-runtime/index.d.ts",
+          import: "./jsx-runtime/index.mjs",
+          require: "./jsx-runtime/index.js",
+        },
+        "./jsx": "./jsx.d.ts",
+        "./dist/*": "./dist/*",
+        "./package.json": "./package.json",
+      },
+    },
   ]);
 });

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -13,6 +13,15 @@ test("types", () => {
     {
       exports: {
         ".": "./index.mjs",
+        "./feature": "./features/feature.mjs",
+      },
+    },
+    {
+      exports: {
+        node: {
+          import: "./node/index.mjs",
+          require: "./node/index.js",
+        },
       },
     },
     {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -25,6 +25,9 @@ test("types", () => {
       },
     },
     {
+      exports: ["./a.mjs", "./a.d.ts"],
+    },
+    {
       exports: {
         ".": [
           {

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -17,57 +17,14 @@ test("types", () => {
     },
     {
       exports: {
-        ".": {
-          import: {
-            types: "./dist/vue.d.mts",
-            node: "./index.mjs",
-            default: "./dist/vue.runtime.esm-bundler.js",
+        ".": [
+          {
+            import: "./esm/index.js",
+            require: "./cjs/index.js",
           },
-          require: {
-            types: "./dist/vue.d.ts",
-            node: {
-              production: "./dist/vue.cjs.prod.js",
-              development: "./dist/vue.cjs.js",
-              default: "./index.js",
-            },
-            default: "./index.js",
-          },
-        },
-        "./server-renderer": {
-          import: {
-            types: "./server-renderer/index.d.mts",
-            default: "./server-renderer/index.mjs",
-          },
-          require: {
-            types: "./server-renderer/index.d.ts",
-            default: "./server-renderer/index.js",
-          },
-        },
-        "./compiler-sfc": {
-          import: {
-            types: "./compiler-sfc/index.d.mts",
-            browser: "./compiler-sfc/index.browser.mjs",
-            default: "./compiler-sfc/index.mjs",
-          },
-          require: {
-            types: "./compiler-sfc/index.d.ts",
-            browser: "./compiler-sfc/index.browser.js",
-            default: "./compiler-sfc/index.js",
-          },
-        },
-        "./jsx-runtime": {
-          types: "./jsx-runtime/index.d.ts",
-          import: "./jsx-runtime/index.mjs",
-          require: "./jsx-runtime/index.js",
-        },
-        "./jsx-dev-runtime": {
-          types: "./jsx-runtime/index.d.ts",
-          import: "./jsx-runtime/index.mjs",
-          require: "./jsx-runtime/index.js",
-        },
-        "./jsx": "./jsx.d.ts",
-        "./dist/*": "./dist/*",
-        "./package.json": "./package.json",
+          "./fallback/index.js",
+        ],
+        "./feature": ["./features/feature.mjs", "./features/feature.js"],
       },
     },
   ]);


### PR DESCRIPTION
Fixes regression from #183

Exports field can be string or a nested object. But not an array of string. Passes tests for vue.js case at least.