### PR TITLE
refactor!: improve resolving and install size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,16 +229,19 @@ export async function findWorkspaceDir(
 
 // --- internal ---
 
- function _resolvePath(id: string, opts: ResolveOptions = {}) {
+function _resolvePath(id: string, opts: ResolveOptions = {}) {
   if (isAbsolute(id)) {
     return id;
   }
   try {
     // TODO: Support import.meta.main when available to prefer over cwd()
     // https://github.com/nodejs/node/issues/49440
-    const resolved = import.meta.resolve(id, opts.parent || opts.url || process.cwd());
+    const resolved = import.meta.resolve(
+      id,
+      opts.parent || opts.url || process.cwd(),
+    );
     if (resolved && typeof resolved === "string") {
-      return normalize(fileURLToPath(resolved))
+      return normalize(fileURLToPath(resolved));
     }
   } catch {
     // Ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,7 @@ export async function resolvePackageJSON(
 ): Promise<string> {
   return findNearestFile("package.json", {
     ...options,
-    startingFrom: await _resolvePath(id, options),
+    startingFrom: _resolvePath(id, options),
   });
 }
 
@@ -156,7 +156,7 @@ export async function resolveTSConfig(
 ): Promise<string> {
   return findNearestFile("tsconfig.json", {
     ...options,
-    startingFrom: await _resolvePath(id, options),
+    startingFrom: _resolvePath(id, options),
   });
 }
 
@@ -181,7 +181,7 @@ export async function resolveLockfile(
 ): Promise<string> {
   return findNearestFile(lockFiles, {
     ...options,
-    startingFrom: await _resolvePath(id, options),
+    startingFrom: _resolvePath(id, options),
   });
 }
 
@@ -197,7 +197,7 @@ export async function findWorkspaceDir(
   options: ResolveOptions = {},
 ): Promise<string> {
   // Resolve the starting path
-  const startingFrom = await _resolvePath(id, options);
+  const startingFrom = _resolvePath(id, options);
   options = { startingFrom, ...options } as ResolveOptions;
 
   // Lookdown for .git/config

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
 import { promises as fsp } from "node:fs";
 import { dirname, resolve, isAbsolute } from "pathe";
-import { type ResolveOptions as _ResolveOptions, resolvePath } from "mlly";
-import { findFile, type FindFileOptions, findNearestFile } from "./utils";
+import {
+  type FindFileOptions,
+  findNearestFile,
+  findFarthestFile,
+} from "./utils";
 import type { PackageJson, TSConfig } from "./types";
 import { parseJSONC, parseJSON, stringifyJSON, stringifyJSONC } from "confbox";
 
@@ -11,7 +14,10 @@ export * from "./utils";
 /**
  * Represents the options for resolving paths with additional file finding capabilities.
  */
-export type ResolveOptions = _ResolveOptions & FindFileOptions;
+export type ResolveOptions = Omit<FindFileOptions, "startingFrom"> & {
+  /** @deprecated: use parent */ url?: string;
+  parent?: string;
+};
 
 /**
  * Options for reading files with optional caching.
@@ -131,10 +137,9 @@ export async function resolvePackageJSON(
   id: string = process.cwd(),
   options: ResolveOptions = {},
 ): Promise<string> {
-  const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, options);
   return findNearestFile("package.json", {
-    startingFrom: resolvedPath,
     ...options,
+    startingFrom: await _resolvePath(id, options),
   });
 }
 
@@ -148,10 +153,9 @@ export async function resolveTSConfig(
   id: string = process.cwd(),
   options: ResolveOptions = {},
 ): Promise<string> {
-  const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, options);
   return findNearestFile("tsconfig.json", {
-    startingFrom: resolvedPath,
     ...options,
+    startingFrom: await _resolvePath(id, options),
   });
 }
 
@@ -174,16 +178,10 @@ export async function resolveLockfile(
   id: string = process.cwd(),
   options: ResolveOptions = {},
 ): Promise<string> {
-  const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, options);
-  const _options = { startingFrom: resolvedPath, ...options };
-
-  try {
-    return await findNearestFile(lockFiles, _options);
-  } catch {
-    // Ignore
-  }
-
-  throw new Error("No lockfile found from " + id);
+  return findNearestFile(lockFiles, {
+    ...options,
+    startingFrom: await _resolvePath(id, options),
+  });
 }
 
 /**
@@ -197,12 +195,13 @@ export async function findWorkspaceDir(
   id: string = process.cwd(),
   options: ResolveOptions = {},
 ): Promise<string> {
-  const resolvedPath = isAbsolute(id) ? id : await resolvePath(id, options);
-  const _options = { startingFrom: resolvedPath, ...options };
+  // Resolve the starting path
+  const startingFrom = await _resolvePath(id, options);
+  options = { startingFrom, ...options } as ResolveOptions;
 
-  // Lookup for .git/config
+  // Lookdown for .git/config
   try {
-    const r = await findNearestFile(".git/config", _options);
+    const r = await findFarthestFile(".git/config", options);
     return resolve(r, "../..");
   } catch {
     // Ignore
@@ -210,22 +209,33 @@ export async function findWorkspaceDir(
 
   // Lookdown for lockfile
   try {
-    const r = await resolveLockfile(resolvedPath, {
-      ..._options,
-      reverse: true,
-    });
+    const r = await findFarthestFile(lockFiles, options);
     return dirname(r);
   } catch {
     // Ignore
   }
 
-  // Lookdown for package.json
+  // Lookup for package.json
   try {
-    const r = await findFile(resolvedPath, _options);
+    const r = await findNearestFile("package.json", options);
     return dirname(r);
   } catch {
     // Ignore
   }
 
   throw new Error("Cannot detect workspace root from " + id);
+}
+
+async function _resolvePath(id: string, opts: ResolveOptions = {}) {
+  if (isAbsolute(id)) {
+    return id;
+  }
+  try {
+    // TODO: Support import.meta.main when available to prefer over cwd()
+    //  https://github.com/nodejs/node/issues/49440
+    id = await import.meta.resolve(id, opts.parent || opts.url || process.cwd());
+  } catch {
+    // Ignore
+  }
+  return id;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { promises as fsp } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, resolve, isAbsolute, normalize } from "pathe";
+import { dirname, resolve, isAbsolute } from "pathe";
 import {
   type FindFileOptions,
   findNearestFile,
@@ -241,7 +241,7 @@ function _resolvePath(id: string, opts: ResolveOptions = {}) {
       opts.parent || opts.url || process.cwd(),
     );
     if (resolved && typeof resolved === "string") {
-      return normalize(fileURLToPath(resolved));
+      return fileURLToPath(resolved);
     }
   } catch {
     // Ignore

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,7 +120,7 @@ export function findNearestFile(
  * @returns A promise that resolves to the path of the farthest file found.
  */
 export function findFarthestFile(
-  filename: string,
+  filename: string | string[],
   _options: FindFileOptions = {},
 ): Promise<string> {
   return findFile(filename, { ..._options, reverse: true });


### PR DESCRIPTION
This PR reduces install size by replacing mlly resolver with `import.meta.resolve` -- which is a breaking change in terms of Node.js runtime support but ~ behavior

(mlly, has [1.2mb](https://packagephobia.com/result?p=mllyc) install size, and while powerful for build-time tooling, in the low-level dep chain like `nypm` > `pkg-types` is little oversized and it can grow with https://github.com/unjs/mlly/issues/219)

--

This PR also includes unrelated change to improve `findWorkspaceDir` behavior:

- Git directory is looked down similar to lockfile (so we don't wrongly detect sub-modules
- Fixed lookup for `package.json`