### PR TITLE
fix: use exsolve for resolving paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "confbox": "^0.1.8",
+    "exsolve": "^1.0.1",
     "pathe": "^2.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       confbox:
         specifier: ^0.1.8
         version: 0.1.8
+      exsolve:
+        specifier: ^1.0.1
+        version: 1.0.1
       pathe:
         specifier: ^2.0.3
         version: 2.0.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { promises as fsp } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve, isAbsolute } from "pathe";
+import { dirname, resolve } from "pathe";
 import { parseJSONC, parseJSON, stringifyJSON, stringifyJSONC } from "confbox";
 import {
   type FindFileOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { promises as fsp } from "node:fs";
 import { dirname, resolve } from "pathe";
 import { parseJSONC, parseJSON, stringifyJSON, stringifyJSONC } from "confbox";
+import { resolveModulePath } from "exsolve";
+
 import {
   type FindFileOptions,
   findNearestFile,
@@ -9,7 +11,6 @@ import {
 
 import type { PackageJson } from "./packagejson.ts";
 import type { TSConfig } from "./tsconfig.ts";
-import { resolveModulePath } from "exsolve";
 
 export type {
   PackageJson,

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,8 +245,10 @@ export async function findWorkspaceDir(
 // --- internal ---
 
 function _resolvePath(id: string, opts: ResolveOptions = {}) {
-  return resolveModulePath(id, {
-    try: true,
-    from: opts.parent || opts.url  /* default is cwd */
-  }) || id
+  return (
+    resolveModulePath(id, {
+      try: true,
+      from: opts.parent || opts.url /* default is cwd */,
+    }) || id
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 
 import type { PackageJson } from "./packagejson.ts";
 import type { TSConfig } from "./tsconfig.ts";
+import { resolveModulePath } from "exsolve";
 
 export type {
   PackageJson,
@@ -244,21 +245,8 @@ export async function findWorkspaceDir(
 // --- internal ---
 
 function _resolvePath(id: string, opts: ResolveOptions = {}) {
-  if (isAbsolute(id)) {
-    return id;
-  }
-  try {
-    // TODO: Support import.meta.main when available to prefer over cwd()
-    // https://github.com/nodejs/node/issues/49440
-    const resolved = import.meta.resolve(
-      id,
-      opts.parent || opts.url || process.cwd(),
-    );
-    if (resolved && typeof resolved === "string") {
-      return fileURLToPath(resolved);
-    }
-  } catch {
-    // Ignore
-  }
-  return id;
+  return resolveModulePath(id, {
+    try: true,
+    from: opts.parent || opts.url  /* default is cwd */
+  }) || id
 }


### PR DESCRIPTION
#213 changed from mlly to `import.meta.resolve` but it has issues when used in some environments also can bypass without resolving.

This PR migrates to [exsolve](https://github.com/unjs/exsolve) to improve stability