### PR TITLE
fix: avoid fallback if starting point cannot be resolved

### DIFF
--- a/src/resolve/internal.ts
+++ b/src/resolve/internal.ts
@@ -1,11 +1,19 @@
+import { isAbsolute, normalize } from "pathe";
 import type { ResolveOptions } from "./types";
 import { resolveModulePath } from "exsolve";
+import { fileURLToPath } from "node:url";
 
-export function _resolvePath(id: string, opts: ResolveOptions = {}) {
-  return (
-    resolveModulePath(id, {
-      try: true,
-      from: opts.parent || opts.url /* default is cwd */,
-    }) || id
-  );
+export function _resolvePath(id: URL | string, opts: ResolveOptions = {}) {
+  if (id instanceof URL || id.startsWith("file://")) {
+    return normalize(fileURLToPath(id));
+  }
+
+  if (isAbsolute(id)) {
+    return normalize(id);
+  }
+
+  return resolveModulePath(id, {
+    ...opts,
+    from: opts.from || opts.parent || opts.url /* default is cwd */,
+  })
 }

--- a/src/resolve/internal.ts
+++ b/src/resolve/internal.ts
@@ -15,5 +15,5 @@ export function _resolvePath(id: URL | string, opts: ResolveOptions = {}) {
   return resolveModulePath(id, {
     ...opts,
     from: opts.from || opts.parent || opts.url /* default is cwd */,
-  })
+  });
 }

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -1,8 +1,13 @@
+import type { ResolveOptions as ExsolveResolveOptions } from "exsolve";
+
 /**
  * Represents the options for resolving paths with additional file finding capabilities.
  */
-export type ResolveOptions = Omit<FindFileOptions, "startingFrom"> & {
-  /** @deprecated: use parent */ url?: string;
+export type ResolveOptions = Omit<FindFileOptions, "startingFrom"> & ExsolveResolveOptions & {
+  /** @deprecated: use `from` */
+  url?: string;
+
+  /** @deprecated: use `from` */
   parent?: string;
 };
 

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -3,13 +3,14 @@ import type { ResolveOptions as ExsolveResolveOptions } from "exsolve";
 /**
  * Represents the options for resolving paths with additional file finding capabilities.
  */
-export type ResolveOptions = Omit<FindFileOptions, "startingFrom"> & ExsolveResolveOptions & {
-  /** @deprecated: use `from` */
-  url?: string;
+export type ResolveOptions = Omit<FindFileOptions, "startingFrom"> &
+  ExsolveResolveOptions & {
+    /** @deprecated: use `from` */
+    url?: string;
 
-  /** @deprecated: use `from` */
-  parent?: string;
-};
+    /** @deprecated: use `from` */
+    parent?: string;
+  };
 
 /**
  * Options for reading files with optional caching.


### PR DESCRIPTION
We had a regression in v2 where if the starting point passed to utils cannot be resolved, it would fallback to original id (which is wrong assumption).

This PR changes behavior to be more strict.