### PR TITLE
feat: git config utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ import { findWorkspaceDir } from "pkg-types";
 const workspaceDir = await findWorkspaceDir(".");
 ```
 
+### `findGitConfig`
+
+[TODO]
+
 ## Types
 
 **Note:** In order to make types working, you need to install `typescript` as a devDependency.
@@ -132,7 +136,7 @@ const workspaceDir = await findWorkspaceDir(".");
 You can directly use typed interfaces:
 
 ```ts
-import type { TSConfig, PackageJSON } from "pkg-types";
+import type { TSConfig, PackageJSON, GitConfig } from "pkg-types";
 ```
 
 You can also use define utils for type support for using in plain `.js` files and auto-complete in IDE.
@@ -147,6 +151,12 @@ const pkg = definePackageJSON({})
 import type { defineTSConfig } from 'pkg-types'
 
 const pkg = defineTSConfig({})
+```
+
+```js
+import type { defineGitConfig } from 'pkg-types'
+
+const gitConfig = defineGitConfig({})
 ```
 
 ## Alternatives

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ const workspaceDir = await findWorkspaceDir(".");
 
 ### `resolveGitConfig`
 
-Asynchronously finds closest `.git/config` file.
+Finds closest `.git/config` file.
 
 ```js
 import { resolveGitConfig } from "pkg-types";
@@ -137,7 +137,7 @@ const gitConfig = await resolveGitConfig(".")
 
 ### `readGitConfig`
 
-Asynchronously finds closest `.git/config` file as a js object.
+Finds and reads closest `.git/config` file into a JS object.
 
 ```js
 import { resolveGitConfig } from "pkg-types";
@@ -147,17 +147,17 @@ const gitConfig = await readGitConfig(".")
 
 ### `writeGitConfig`
 
-Stringifies GitConfig into INI text format and asynchronously writes git config to a file.
+Stringifies git config object into INI text format and writes it to a file.
 
 ```js
-import { resolveGitConfig } from "pkg-types";
+import { writeGitConfig } from "pkg-types";
 
-const gitConfig = await readGitConfig(".")
+const gitConfig = await writeGitConfig(".git/config", gitConfig)
 ```
 
 ### `parseGitConfig`
 
-parse git config INI format into a JS object.
+Parses a git config file in INI text format into a JavaScript object.
 
 ```js
 import { parseGitConfig } from "pkg-types";
@@ -167,14 +167,13 @@ const gitConfig = parseGitConfig(".")
 
 ### `stringifyGitConfig`
 
-stringify git JS config object into INI text format.
+Stringifies a git config object into a git config file INI text format.
 
 ```js
 import { parseGitConfig } from "pkg-types";
 
 const stringifyGitConfig = stringifyGitConfig(".")
 ```
-
 
 ## Types
 

--- a/README.md
+++ b/README.md
@@ -125,9 +125,56 @@ import { findWorkspaceDir } from "pkg-types";
 const workspaceDir = await findWorkspaceDir(".");
 ```
 
-### `findGitConfig`
+### `resolveGitConfig`
 
-[TODO]
+Asynchronously finds closest `.git/config` file.
+
+```js
+import { resolveGitConfig } from "pkg-types";
+
+const gitConfig = await resolveGitConfig(".")
+```
+
+### `readGitConfig`
+
+Asynchronously finds closest `.git/config` file as a js object.
+
+```js
+import { resolveGitConfig } from "pkg-types";
+
+const gitConfig = await readGitConfig(".")
+```
+
+### `writeGitConfig`
+
+Stringifies GitConfig into INI text format and asynchronously writes git config to a file.
+
+```js
+import { resolveGitConfig } from "pkg-types";
+
+const gitConfig = await readGitConfig(".")
+```
+
+### `parseGitConfig`
+
+parse git config INI format into a JS object.
+
+```js
+import { parseGitConfig } from "pkg-types";
+
+const gitConfig = parseGitConfig(".")
+```
+
+### `stringifyGitConfig`
+
+stringify git JS config object into INI text format.
+
+```js
+import { parseGitConfig } from "pkg-types";
+
+const stringifyGitConfig = stringifyGitConfig(".")
+```
+
 
 ## Types
 

--- a/src/gitconfig/types.ts
+++ b/src/gitconfig/types.ts
@@ -1,0 +1,32 @@
+export interface GitRemote {
+  [key: string]: unknown;
+  name?: string;
+  url?: string;
+  fetch?: string;
+}
+
+export interface GitBranch {
+  [key: string]: unknown;
+  remote?: string;
+  merge?: string;
+  description?: string;
+  rebase?: boolean;
+}
+
+export interface GitCoreConfig {
+  [key: string]: unknown;
+}
+
+export interface GitConfigUser {
+  [key: string]: unknown;
+  name?: string;
+  email?: string;
+}
+
+export interface GitConfig {
+  [key: string]: unknown;
+  core?: GitCoreConfig;
+  user?: GitConfigUser;
+  remote?: Record<string, GitRemote>;
+  branch?: Record<string, GitBranch>;
+}

--- a/src/gitconfig/utils.ts
+++ b/src/gitconfig/utils.ts
@@ -38,7 +38,7 @@ export async function writeGitConfig(path: string, config: GitConfig) {
  * Parses a git config file INI format into a JavaScript object.
  */
 export function parseGitConfig(blob: string): GitConfig {
-  return parseINI(blob.replaceAll(/^\[(\w+) "(.+)"\]$/gm, '[$1.$2]'));
+  return parseINI(blob.replaceAll(/^\[(\w+) "(.+)"\]$/gm, "[$1.$2]"));
 }
 
 /**

--- a/src/gitconfig/utils.ts
+++ b/src/gitconfig/utils.ts
@@ -1,48 +1,51 @@
 import type { GitConfig } from "./types";
 import { readFile, writeFile } from "node:fs/promises";
 import { findNearestFile } from "../resolve/utils";
-import { parseINI } from "confbox/ini";
-import { stringifyINI } from "confbox";
+import { parseINI, stringifyINI } from "confbox/ini";
+import type { ResolveOptions } from "../resolve/types";
 
 /**
- * Defines a GitConfig structure.
+ * Defines a git config object.
  */
 export function defineGitConfig(config: GitConfig): GitConfig {
   return config;
 }
 
 /**
- * Asynchronously finds closest `.git/config` file.
+ * Finds closest `.git/config` file.
  */
-export async function resolveGitConfig(dir: string): Promise<string> {
-  return findNearestFile(".git/config", { startingFrom: dir });
+export async function resolveGitConfig(
+  dir: string,
+  opts?: ResolveOptions,
+): Promise<string> {
+  return findNearestFile(".git/config", { ...opts, startingFrom: dir });
 }
 
 /**
- * Asynchronously finds and reads closest `.git/config` file as a JS object.
+ * Finds and reads closest `.git/config` file into a JS object.
  */
-export async function readGitConfig(dir: string) {
-  const path = await resolveGitConfig(dir);
-  const blob = await readFile(path, "utf8");
-  return parseGitConfig(blob);
+export async function readGitConfig(dir: string, opts?: ResolveOptions) {
+  const path = await resolveGitConfig(dir, opts);
+  const ini = await readFile(path, "utf8");
+  return parseGitConfig(ini);
 }
 
 /**
- * Stringifies GitConfig into INI text format and asynchronously writes git config to a file.
+ * Stringifies git config object into INI text format and writes it to a file.
  */
 export async function writeGitConfig(path: string, config: GitConfig) {
   await writeFile(path, stringifyGitConfig(config));
 }
 
 /**
- * Parses a git config file INI format into a JavaScript object.
+ * Parses a git config file in INI text format into a JavaScript object.
  */
-export function parseGitConfig(blob: string): GitConfig {
-  return parseINI(blob.replaceAll(/^\[(\w+) "(.+)"\]$/gm, "[$1.$2]"));
+export function parseGitConfig(ini: string): GitConfig {
+  return parseINI(ini.replaceAll(/^\[(\w+) "(.+)"\]$/gm, "[$1.$2]"));
 }
 
 /**
- * Stringifies a git config object into a git config file INI format.
+ * Stringifies a git config object into a git config file INI text format.
  */
 export function stringifyGitConfig(config: GitConfig): string {
   return stringifyINI(config).replaceAll(/^\[(\w+)\.(\w+)\]$/gm, '[$1 "$2"]');

--- a/src/gitconfig/utils.ts
+++ b/src/gitconfig/utils.ts
@@ -38,19 +38,7 @@ export async function writeGitConfig(path: string, config: GitConfig) {
  * Parses a git config file INI format into a JavaScript object.
  */
 export function parseGitConfig(blob: string): GitConfig {
-  const gitConfig: GitConfig = {};
-
-  for (const [key, value] of Object.entries(parseINI(blob) as object)) {
-    const [_, parentKey, scopeKey] = key.match(/^(\w+)\s+"(.+)"$/) || [];
-    let scope = gitConfig as any;
-    if (parentKey) {
-      gitConfig[parentKey] ??= {};
-      scope = gitConfig[parentKey as keyof GitConfig];
-    }
-    scope[scopeKey || key] = value;
-  }
-
-  return gitConfig;
+  return parseINI(blob.replaceAll(/^\[(\w+) "(.+)"\]$/gm, '[$1.$2]'));
 }
 
 /**

--- a/src/gitconfig/utils.ts
+++ b/src/gitconfig/utils.ts
@@ -19,7 +19,7 @@ export async function resolveGitConfig(dir: string): Promise<string> {
 }
 
 /**
- * Asynchronously finds and reads closest `.git/config` file.
+ * Asynchronously finds and reads closest `.git/config` file as a JS object.
  */
 export async function readGitConfig(dir: string) {
   const path = await resolveGitConfig(dir);
@@ -28,7 +28,7 @@ export async function readGitConfig(dir: string) {
 }
 
 /**
- * Asynchronously writes git config to a file.
+ * Stringifies GitConfig into INI text format and asynchronously writes git config to a file.
  */
 export async function writeGitConfig(path: string, config: GitConfig) {
   await writeFile(path, stringifyGitConfig(config));

--- a/src/gitconfig/utils.ts
+++ b/src/gitconfig/utils.ts
@@ -1,0 +1,61 @@
+import type { GitConfig } from "./types";
+import { readFile, writeFile } from "node:fs/promises";
+import { findNearestFile } from "../resolve/utils";
+import { parseINI } from "confbox/ini";
+import { stringifyINI } from "confbox";
+
+/**
+ * Defines a GitConfig structure.
+ */
+export function defineGitConfig(config: GitConfig): GitConfig {
+  return config;
+}
+
+/**
+ * Asynchronously finds closest `.git/config` file.
+ */
+export async function resolveGitConfig(dir: string): Promise<string> {
+  return findNearestFile(".git/config", { startingFrom: dir });
+}
+
+/**
+ * Asynchronously finds and reads closest `.git/config` file.
+ */
+export async function readGitConfig(dir: string) {
+  const path = await resolveGitConfig(dir);
+  const blob = await readFile(path, "utf8");
+  return parseGitConfig(blob);
+}
+
+/**
+ * Asynchronously writes git config to a file.
+ */
+export async function writeGitConfig(path: string, config: GitConfig) {
+  await writeFile(path, stringifyGitConfig(config));
+}
+
+/**
+ * Parses a git config file INI format into a JavaScript object.
+ */
+export function parseGitConfig(blob: string): GitConfig {
+  const gitConfig: GitConfig = {};
+
+  for (const [key, value] of Object.entries(parseINI(blob) as object)) {
+    const [_, parentKey, scopeKey] = key.match(/^(\w+)\s+"(.+)"$/) || [];
+    let scope = gitConfig as any;
+    if (parentKey) {
+      gitConfig[parentKey] ??= {};
+      scope = gitConfig[parentKey as keyof GitConfig];
+    }
+    scope[scopeKey || key] = value;
+  }
+
+  return gitConfig;
+}
+
+/**
+ * Stringifies a git config object into a git config file INI format.
+ */
+export function stringifyGitConfig(config: GitConfig): string {
+  return stringifyINI(config).replaceAll(/^\[(\w+)\.(\w+)\]$/gm, '[$1 "$2"]');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,3 +35,22 @@ export {
   resolveLockfile,
   findWorkspaceDir,
 } from "./packagejson/utils";
+
+// --- git config ---
+
+export type {
+  GitConfig,
+  GitBranch,
+  GitCoreConfig,
+  GitRemote,
+  GitConfigUser
+} from "./gitconfig/types";
+
+export {
+  defineGitConfig,
+  readGitConfig,
+  writeGitConfig,
+  resolveGitConfig,
+  parseGitConfig,
+  stringifyGitConfig,
+} from "./gitconfig/utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export type {
   GitBranch,
   GitCoreConfig,
   GitRemote,
-  GitConfigUser
+  GitConfigUser,
 } from "./gitconfig/types";
 
 export {

--- a/test/fixture/_git/config
+++ b/test/fixture/_git/config
@@ -1,0 +1,19 @@
+[core]
+repositoryformatversion = 0
+filemode = true
+bare = false
+logallrefupdates = true
+ignorecase = true
+precomposeunicode = true
+
+[branch "main"]
+remote = origin
+merge = refs/heads/main
+
+[branch "develop"]
+remote = origin
+merge = refs/heads/develop
+
+[remote "origin"]
+url = https://github.com/username/repo.git
+fetch = +refs/heads/*:refs/remotes/origin/*


### PR DESCRIPTION
Add utils to resolve, read, and write git config (`.git/config`). 

This is helpful to find information about current project linked to its git repoistory.