### PR TITLE
feat(findWorkspaceDir): detect workspace files

### DIFF
--- a/src/packagejson/utils.ts
+++ b/src/packagejson/utils.ts
@@ -125,7 +125,7 @@ export async function findWorkspaceDir(
   // Lookdown for known workspace files
   try {
     const r = await findFarthestFile(workspaceFiles, options);
-    return dirname(r)
+    return dirname(r);
   } catch {
     // Ignore
   }

--- a/src/packagejson/utils.ts
+++ b/src/packagejson/utils.ts
@@ -16,6 +16,13 @@ const lockFiles = [
   "bun.lock",
 ];
 
+const workspaceFiles = [
+  "pnpm-workspace.yaml",
+  "lerna.json",
+  "turbo.json",
+  "rush.json",
+];
+
 const FileCache = /* #__PURE__ */ new Map<string, Record<string, any>>();
 
 /**
@@ -114,6 +121,14 @@ export async function findWorkspaceDir(
   // Resolve the starting path
   const startingFrom = _resolvePath(id, options);
   options = { startingFrom, ...options } as ResolveOptions;
+
+  // Lookdown for known workspace files
+  try {
+    const r = await findFarthestFile(workspaceFiles, options);
+    return dirname(r)
+  } catch {
+    // Ignore
+  }
 
   // Lookdown for .git/config
   try {


### PR DESCRIPTION
(context: discusisons in #218)

Detect known workspace files with highest priority for `findWorkspaceDir`. 


Thinking to also support detection of npm `workspaces`, however costs little (and we do it as last fallback anyway..)