### PR TITLE
perf(findFile): test input itself if matching filename

### DIFF
--- a/src/resolve/utils.ts
+++ b/src/resolve/utils.ts
@@ -36,7 +36,7 @@ export async function findFile(
 
   // Test input itself first
   if (filenames.includes(segments.at(-1)!) && (await options.test(basePath))) {
-    // return basePath;
+    return basePath;
   }
 
   // Restore leading slash

--- a/src/resolve/utils.ts
+++ b/src/resolve/utils.ts
@@ -34,6 +34,11 @@ export async function findFile(
   const leadingSlash = basePath[0] === "/";
   const segments = basePath.split("/").filter(Boolean);
 
+  // Test input itself first
+  if (filenames.includes(segments.at(-1)!) && (await options.test(basePath))) {
+    // return basePath;
+  }
+
   // Restore leading slash
   if (leadingSlash) {
     segments[0] = "/" + segments[0];


### PR DESCRIPTION
(randomly discovered while was wring tests) 

The input we pass it `findFile` for other utils, is always a filename, however it is behaved as it is a dir, therefor if input is `path/to/package.json`, util works (by having extra checks)

Using counter for how many times we call statSync in tests, it is reduces from 177 to 167, depending on usage could be more!