### PR TITLE
fix: pretty print new `package.json` files

### DIFF
--- a/src/packagejson/utils.ts
+++ b/src/packagejson/utils.ts
@@ -76,7 +76,7 @@ export async function writePackageJSON(
   path: string,
   pkg: PackageJson,
 ): Promise<void> {
-  await fsp.writeFile(path, stringifyJSON(pkg));
+  await fsp.writeFile(path, stringifyJSON(pkg, { indent: 2 }));
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -92,6 +92,12 @@ describe("package.json", () => {
     ).to.equal("1.0.0");
   });
 
+  it("pretty prints package.json when writing", async () => {
+    await writePackageJSON(rFixture("package.json.tmp"), { version: "1.0.0" });
+    const contents = await readFile(rFixture("package.json.tmp"), "utf8");
+    expect(contents).to.equal(JSON.stringify({ version: "1.0.0" }, undefined, 2));
+  });
+
   it("correctly reads a version from absolute path", async () => {
     expect(
       await readPackageJSON(rFixture(".")).then((p) => p?.version),

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -95,7 +95,9 @@ describe("package.json", () => {
   it("pretty prints package.json when writing", async () => {
     await writePackageJSON(rFixture("package.json.tmp"), { version: "1.0.0" });
     const contents = await readFile(rFixture("package.json.tmp"), "utf8");
-    expect(contents).to.equal(JSON.stringify({ version: "1.0.0" }, undefined, 2));
+    expect(contents).to.equal(
+      JSON.stringify({ version: "1.0.0" }, undefined, 2),
+    );
   });
 
   it("correctly reads a version from absolute path", async () => {


### PR DESCRIPTION
When a `package.json` is read via pkg-types, we store the indent level for later use and apply it when writing the same file.

However, if we store an object which wasn't originally read via pkg-types, we don't have this information and will write the file with no indentation (i.e. the output of `JSON.stringify(obj)`).

This fix changes the behaviour such that read/writes still retain the indentation information, but new files default to `indent: 2`.


