### PR TITLE
feat(packagejson): autocompletion for script names.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,11 @@
     "unbuild": "^3.5.0",
     "vitest": "^3.0.7"
   },
-  "packageManager": "pnpm@10.5.2"
+  "packageManager": "pnpm@10.5.2",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild"
+    ]
+  }
 }

--- a/src/packagejson/types.ts
+++ b/src/packagejson/types.ts
@@ -62,7 +62,7 @@ export interface PackageJson {
   /**
    * The `scripts` field is a dictionary containing script commands that are run at various times in the lifecycle of your package.
    */
-  scripts?: Record<string, string>;
+  scripts?: PackageJsonScripts;
 
   /**
    * If you set `"private": true` in your package.json, then npm will refuse to publish it.
@@ -299,6 +299,43 @@ export interface PackageJson {
 
   [key: string]: any;
 }
+
+/**
+ * See: https://docs.npmjs.com/cli/v11/using-npm/scripts#pre--post-scripts
+ */
+type PackageJsonScriptWithPreAndPost<S extends string> =
+  | S
+  | `${"pre" | "post"}${S}`;
+
+/**
+ * See: https://docs.npmjs.com/cli/v11/using-npm/scripts#life-cycle-operation-order
+ */
+type PackageJsonNpmLifeCycleScripts =
+  | "dependencies"
+  | PackageJsonScriptWithPreAndPost<"install">
+  | PackageJsonScriptWithPreAndPost<"pack">
+  | PackageJsonScriptWithPreAndPost<"prepare">
+  | "prepublishOnly"
+  | PackageJsonScriptWithPreAndPost<"publish">
+  | PackageJsonScriptWithPreAndPost<"restart">
+  | PackageJsonScriptWithPreAndPost<"start">
+  | PackageJsonScriptWithPreAndPost<"stop">
+  | PackageJsonScriptWithPreAndPost<"test">
+  | PackageJsonScriptWithPreAndPost<"version">;
+
+/**
+ * See: https://pnpm.io/scripts#lifecycle-scripts
+ */
+type PackageJsonPnpmLifeCycleScripts = "pnpm:devPreinstall";
+
+type PackageJsonScriptName =
+  | PackageJsonNpmLifeCycleScripts
+  | PackageJsonPnpmLifeCycleScripts
+  | (string & {});
+
+export type PackageJsonScripts = {
+  [P in PackageJsonScriptName]?: string;
+};
 
 /**
  * A “person” is an object with a “name” field and optionally “url” and “email”. Or you can shorten that all into a single string, and npm will parse it for you.

--- a/src/packagejson/types.ts
+++ b/src/packagejson/types.ts
@@ -328,7 +328,22 @@ type PackageJsonNpmLifeCycleScripts =
  */
 type PackageJsonPnpmLifeCycleScripts = "pnpm:devPreinstall";
 
+type PackageJsonCommonScripts =
+  | "bench"
+  | "build"
+  | "clean"
+  | "coverage"
+  | "deploy"
+  | "dev"
+  | "format"
+  | "lint"
+  | "preview"
+  | "release"
+  | "typecheck"
+  | "watch";
+
 type PackageJsonScriptName =
+  | PackageJsonCommonScripts
   | PackageJsonNpmLifeCycleScripts
   | PackageJsonPnpmLifeCycleScripts
   | (string & {});


### PR DESCRIPTION
Hey :wave:

Thanks for this awesome package! Have been using it in various projects, it's my go-to for `package.json` and `tsconfig.json` types and utilities.

This PR adds autocompletion for `package.json`'s `scripts` object keys - `npm` and `pnpm` life cycle script names, and some common scripts from across the ecosystem.