### PR TITLE
feat(readPackage): implement `try` option to suppress file-not-found errors

### DIFF
--- a/src/packagejson/utils.ts
+++ b/src/packagejson/utils.ts
@@ -73,12 +73,13 @@ export async function readPackage(
   id?: string,
   options: ResolveOptions & ReadOptions = {},
 ): Promise<PackageJson | undefined> {
-  const resolvedPath = await findPackage(id, options).catch(() => {
+  const resolvedPath = await findPackage(id, options).catch((err: unknown) => {
     if (options.try) {
       return undefined;
     }
     throw new Error(
-      `Cannot find matching ${packageFiles} in ${id || process.cwd()} or parent directories`,
+      `Cannot find matching ${packageFiles.join(", ")} in ${id || process.cwd()} or parent directories`,
+      { cause: err },
     );
   });
   if (!resolvedPath) {

--- a/src/packagejson/utils.ts
+++ b/src/packagejson/utils.ts
@@ -72,8 +72,18 @@ export async function findPackage(
 export async function readPackage(
   id?: string,
   options: ResolveOptions & ReadOptions = {},
-): Promise<PackageJson> {
-  const resolvedPath = await findPackage(id, options);
+): Promise<PackageJson | undefined> {
+  const resolvedPath = await findPackage(id, options).catch(() => {
+    if (options.try) {
+      return undefined;
+    }
+    throw new Error(
+      `Cannot find matching ${packageFiles} in ${id || process.cwd()} or parent directories`,
+    );
+  });
+  if (!resolvedPath) {
+    return undefined;
+  }
   const cache = options.cache && typeof options.cache !== "boolean" ? options.cache : FileCache;
   if (options.cache && cache.has(resolvedPath)) {
     return cache.get(resolvedPath)!;

--- a/src/resolve/types.ts
+++ b/src/resolve/types.ts
@@ -21,6 +21,11 @@ export type ReadOptions = {
    * Can be a boolean or a map to hold the cached data.
    */
   cache?: boolean | Map<string, Record<string, any>>;
+
+  /**
+   * When `true`, suppresses file-not-found errors and returns `undefined` instead.
+   */
+  try?: boolean;
 };
 
 export interface FindFileOptions {


### PR DESCRIPTION
## Problem

`readPackage()` accepts a `try` option in its type signature (inherited from exsolve's `ResolveOptions`), but the option is not implemented. When `try: true`, the function should return `undefined` instead of throwing when no package file is found.

## Changes

- Modified `readPackage()` to catch `findPackage()` errors and return `undefined` when `try: true`
- Added explicit `try?: boolean` to `ReadOptions` type for clarity and discoverability

## Closes

Closes #257


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional error handling for package resolution. When enabled, operations return undefined instead of throwing errors when package files cannot be found. Error handling behavior is controlled via a configuration flag.
  * Enhanced error messages provide detailed context about which package files couldn't be resolved from the specified location or working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->