### PR TITLE
fix(gitconfig): resolve file URLs in resolveGitConfig

### DIFF
--- a/src/gitconfig/utils.ts
+++ b/src/gitconfig/utils.ts
@@ -1,6 +1,7 @@
 import type { GitConfig } from "./types";
 import { readFile, writeFile } from "node:fs/promises";
 import { findNearestFile } from "../resolve/utils";
+import { _resolvePath } from "../resolve/internal";
 import { parseINI, stringifyINI } from "confbox/ini";
 import type { ResolveOptions } from "../resolve/types";
 
@@ -15,7 +16,10 @@ export function defineGitConfig(config: GitConfig): GitConfig {
  * Finds closest `.git/config` file.
  */
 export async function resolveGitConfig(dir: string, opts?: ResolveOptions): Promise<string> {
-  return findNearestFile(".git/config", { ...opts, startingFrom: dir });
+  return findNearestFile(".git/config", {
+    ...opts,
+    startingFrom: _resolvePath(dir, opts),
+  });
 }
 
 /**

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { cp, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "pathe";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
@@ -252,6 +252,12 @@ describe(".git/config", () => {
 
   it("resolveGitConfig", async () => {
     expect(await resolveGitConfig(rFixture("."))).to.equal(rFixture(".git/config"));
+  });
+
+  it("resolveGitConfig (file:// url)", async () => {
+    expect(await resolveGitConfig(pathToFileURL(rFixture(".")).href)).to.equal(
+      rFixture(".git/config"),
+    );
   });
 
   it("readGitConfig", async () => {


### PR DESCRIPTION
`resolveGitConfig` / `readGitConfig` pass the input `dir` straight to `findNearestFile` as `startingFrom`, while every other resolver in the package (`resolvePackageJSON`, `resolveTSConfig`, `resolveLockfile`, `findPackage`) first runs the input through `_resolvePath`. Because the input is never normalized, a `file://` URL stays a literal string, so the search starts from `"file:///..."` and never finds the file:

```js
import { resolvePackageJSON, resolveGitConfig } from "pkg-types";

const url = import.meta.url; // file:///...

await resolvePackageJSON(url); // ok
await resolveGitConfig(url);   // throws: Cannot find matching .git/config in file:///... or parent directories
```

Both functions accept `ResolveOptions`, but the resolution options (`from` / `parent` / `url`) were ignored for the same reason.

This routes `dir` through `_resolvePath(dir, opts)` so `resolveGitConfig` handles file URLs and resolution options the same way as the other resolvers. Absolute paths are unchanged (they are just normalized, as in the siblings). Added a test for `file://` URL input.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git config lookup so it correctly resolves the starting directory before searching for the nearest `.git/config`.
  * Added support for resolving Git config paths when the input is provided as a `file://` URL.

* **Tests**
  * Added coverage for `file://` URL-based Git config resolution to ensure it returns the expected config contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->