### PR TITLE
perf: load each format's parser only when a file needs it

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typecheck": "tsc --noEmit --skipLibCheck"
   },
   "dependencies": {
-    "confbox": "^0.2.4",
+    "confbox": "^0.3.0",
     "exsolve": "^1.1.1",
     "pathe": "^2.0.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       confbox:
-        specifier: ^0.2.4
-        version: 0.2.4
+        specifier: ^0.3.0
+        version: 0.3.0
       exsolve:
         specifier: ^1.1.1
         version: 1.1.1
@@ -1092,6 +1092,9 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  confbox@0.3.0:
+    resolution: {integrity: sha512-kwgXY5w5EWPZLpFhvQBPzkujFZtSgq5PtUCoQwfjqkvu5Qgr0w8ctK5zTHOrGLdxTf/5YJf5D5XBnc2UfTAHVw==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -2843,6 +2846,8 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
+
+  confbox@0.3.0: {}
 
   consola@3.4.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ allowBuilds:
   "@parcel/watcher": false
 minimumReleaseAgeExclude:
   - obuild@0.4.39
+  - confbox@0.3.0

--- a/src/packagejson/utils.ts
+++ b/src/packagejson/utils.ts
@@ -1,14 +1,7 @@
 import { promises as fsp } from "node:fs";
 import { dirname, resolve } from "pathe";
-import {
-  parseJSONC,
-  parseJSON,
-  stringifyJSON,
-  parseJSON5,
-  stringifyJSON5,
-  parseYAML,
-  stringifyYAML,
-} from "confbox";
+import { parseJSON, stringifyJSON } from "confbox/json";
+import { parseJSONC } from "confbox/jsonc";
 
 import type { ResolveOptions, ReadOptions, FindFileOptions } from "../resolve/types";
 import type { PackageJson } from "./types";
@@ -82,8 +75,10 @@ export async function readPackage(
   let parsed: PackageJson;
 
   if (resolvedPath.endsWith(".json5")) {
+    const { parseJSON5 } = await import("confbox/json5");
     parsed = parseJSON5(blob) as PackageJson;
   } else if (resolvedPath.endsWith(".yaml")) {
+    const { parseYAML } = await import("confbox/yaml");
     parsed = parseYAML(blob) as PackageJson;
   } else {
     try {
@@ -106,8 +101,10 @@ export async function writePackage(path: string, pkg: PackageJson): Promise<void
   let content: string;
 
   if (path.endsWith(".json5")) {
+    const { stringifyJSON5 } = await import("confbox/json5");
     content = stringifyJSON5(pkg);
   } else if (path.endsWith(".yaml")) {
+    const { stringifyYAML } = await import("confbox/yaml");
     content = stringifyYAML(pkg);
   } else {
     content = stringifyJSON(pkg);

--- a/src/tsconfig/utils.ts
+++ b/src/tsconfig/utils.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from "node:fs";
-import { parseJSONC, stringifyJSONC } from "confbox";
+import { parseJSONC, stringifyJSONC } from "confbox/jsonc";
 
 import type { ResolveOptions, ReadOptions } from "../resolve/types";
 import type { TSConfig } from "./types";


### PR DESCRIPTION
resolves #279

Moves each format's parser to the point where a file actually needs it.

`readPackage` and `writePackage` already dispatch on the extension, and both are `async`, so json5 and yaml can load inside their own branches. A plain `package.json` never touches them. The remaining static imports move off the
barrel onto `confbox/json` and `confbox/jsonc`, matching what `src/gitconfig/utils.ts` already does with `confbox/ini`.

### Effect

Importing `pkg-types`:

| | before | after |
| --- | --- | --- |
| modules loaded | 27 | **21** |
| import cost | 9.2 ms | **8.0 ms** |

Dropped from the load path: the `confbox` barrel, json5 + its lib, yaml + js-yaml, toml + smol-toml.

### Not changed

`confbox/ini` stays static — `parseGitConfig` and `stringifyGitConfig` are synchronous exports, so moving it would change their signatures.

### Blocked on unjs/confbox#88

`parseJSON` and `stringifyJSON` are reachable only through the barrel today, so this needs the `confbox/json` subpath first. `pnpm typecheck` fails until that ships and is released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved resource usage by loading JSON5 and YAML support only when those file formats are handled.
* **Compatibility**
  * JSON, JSONC, JSON5, and YAML file handling continues to work as before.
  * Updated configuration parsing support to maintain compatibility with the latest parser improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->