### PR TITLE
fix: inline tsconfig compiler option types

### DIFF
--- a/src/tsconfig/types.ts
+++ b/src/tsconfig/types.ts
@@ -1,26 +1,137 @@
-import type * as ts from "typescript";
-
-export type StripEnums<T extends Record<string, any>> = {
-  [K in keyof T]: T[K] extends boolean
-    ? T[K]
-    : T[K] extends string
-      ? T[K]
-      : T[K] extends object
-        ? T[K]
-        : T[K] extends Array<any>
-          ? T[K]
-          : T[K] extends undefined
-            ? undefined
-            : any;
-};
-
 export interface TSConfig {
-  compilerOptions?: StripEnums<ts.CompilerOptions>;
+  compilerOptions?: CompilerOptions;
   exclude?: string[];
   compileOnSave?: boolean;
   extends?: string | string[];
   files?: string[];
   include?: string[];
-  typeAcquisition?: ts.TypeAcquisition;
+  typeAcquisition?: TypeAcquisition;
   references?: { path: string }[];
+}
+
+/**
+ * Compiler options as they appear in `tsconfig.json`.
+ *
+ * Options that TypeScript models with an enum (`target`, `module`, ...) are typed as `any`,
+ * since in JSON they are written as (case insensitive) strings.
+ */
+export interface CompilerOptions {
+  allowArbitraryExtensions?: boolean;
+  allowImportingTsExtensions?: boolean;
+  allowJs?: boolean;
+  allowNonTsExtensions?: boolean;
+  allowSyntheticDefaultImports?: boolean;
+  allowUmdGlobalAccess?: boolean;
+  allowUnreachableCode?: boolean;
+  allowUnusedLabels?: boolean;
+  alwaysStrict?: boolean;
+  assumeChangesOnlyAffectDirectDependencies?: boolean;
+  baseUrl?: string;
+  checkJs?: boolean;
+  composite?: boolean;
+  customConditions?: string[];
+  declaration?: boolean;
+  declarationDir?: string;
+  declarationMap?: boolean;
+  deduplicatePackages?: boolean;
+  disableReferencedProjectLoad?: boolean;
+  disableSizeLimit?: boolean;
+  disableSolutionSearching?: boolean;
+  disableSourceOfProjectReferenceRedirect?: boolean;
+  downlevelIteration?: boolean;
+  emitBOM?: boolean;
+  emitDeclarationOnly?: boolean;
+  emitDecoratorMetadata?: boolean;
+  erasableSyntaxOnly?: boolean;
+  esModuleInterop?: boolean;
+  exactOptionalPropertyTypes?: boolean;
+  experimentalDecorators?: boolean;
+  forceConsistentCasingInFileNames?: boolean;
+  ignoreConfig?: boolean;
+  ignoreDeprecations?: string;
+  importHelpers?: boolean;
+  importsNotUsedAsValues?: any;
+  incremental?: boolean;
+  init?: boolean;
+  inlineSourceMap?: boolean;
+  inlineSources?: boolean;
+  isolatedDeclarations?: boolean;
+  isolatedModules?: boolean;
+  jsx?: any;
+  jsxFactory?: string;
+  jsxFragmentFactory?: string;
+  jsxImportSource?: string;
+  lib?: string[];
+  libReplacement?: boolean;
+  locale?: string;
+  mapRoot?: string;
+  maxNodeModuleJsDepth?: number;
+  module?: any;
+  moduleDetection?: any;
+  moduleResolution?: any;
+  moduleSuffixes?: string[];
+  newLine?: any;
+  noCheck?: boolean;
+  noEmit?: boolean;
+  noEmitHelpers?: boolean;
+  noEmitOnError?: boolean;
+  noErrorTruncation?: boolean;
+  noFallthroughCasesInSwitch?: boolean;
+  noImplicitAny?: boolean;
+  noImplicitOverride?: boolean;
+  noImplicitReturns?: boolean;
+  noImplicitThis?: boolean;
+  noLib?: boolean;
+  noPropertyAccessFromIndexSignature?: boolean;
+  noResolve?: boolean;
+  noStrictGenericChecks?: boolean;
+  noUncheckedIndexedAccess?: boolean;
+  noUncheckedSideEffectImports?: boolean;
+  noUnusedLocals?: boolean;
+  noUnusedParameters?: boolean;
+  outDir?: string;
+  outFile?: string;
+  paths?: Record<string, string[]>;
+  plugins?: { name: string; [option: string]: any }[];
+  preserveConstEnums?: boolean;
+  preserveSymlinks?: boolean;
+  preserveValueImports?: boolean;
+  project?: string;
+  reactNamespace?: string;
+  removeComments?: boolean;
+  resolveJsonModule?: boolean;
+  resolvePackageJsonExports?: boolean;
+  resolvePackageJsonImports?: boolean;
+  rewriteRelativeImportExtensions?: boolean;
+  rootDir?: string;
+  rootDirs?: string[];
+  skipDefaultLibCheck?: boolean;
+  skipLibCheck?: boolean;
+  sourceMap?: boolean;
+  sourceRoot?: string;
+  stableTypeOrdering?: boolean;
+  strict?: boolean;
+  strictBindCallApply?: boolean;
+  strictBuiltinIteratorReturn?: boolean;
+  strictFunctionTypes?: boolean;
+  strictNullChecks?: boolean;
+  strictPropertyInitialization?: boolean;
+  stripInternal?: boolean;
+  suppressOutputPathCheck?: boolean;
+  target?: any;
+  traceResolution?: boolean;
+  tsBuildInfoFile?: string;
+  typeRoots?: string[];
+  types?: string[];
+  useDefineForClassFields?: boolean;
+  useUnknownInCatchVariables?: boolean;
+  verbatimModuleSyntax?: boolean;
+  [option: string]: any;
+}
+
+export interface TypeAcquisition {
+  enable?: boolean;
+  include?: string[];
+  exclude?: string[];
+  disableFilenameBasedTypeAcquisition?: boolean;
 }


### PR DESCRIPTION
`typescript@7` no longer ships the compiler API types from its root entry: `exports["."]` points to `./lib/version.cjs`, and `TypeAcquisition` is not in the shipped `.d.ts` files at all. This made `tsc --noEmit` fail:

```
src/tsconfig/types.ts:18:35 - error TS2694: Namespace '".../typescript/lib/version"' has no exported member 'CompilerOptions'.
src/tsconfig/types.ts:24:24 - error TS2694: Namespace '".../typescript/lib/version"' has no exported member 'TypeAcquisition'.
```

Instead of chasing the `typescript/unstable/*` subpaths, `CompilerOptions` and `TypeAcquisition` are now defined in-tree. The option list comes from `typescript@7`'s `dist/api/compilerOptions.d.ts`, plus still-valid legacy options it omits (`esModuleInterop`, `baseUrl`, `downlevelIteration`, `outFile`, `preserveValueImports`, `plugins`, ...).

Behavior is kept the same:

- Enum-valued options (`target`, `module`, `moduleResolution`, `jsx`, `newLine`, `moduleDetection`, `importsNotUsedAsValues`) stay typed as `any`, exactly what `StripEnums` produced before, since in JSON they are written as strings.
- The `[option: string]: any` index signature is kept, matching the one TypeScript 5's own `CompilerOptions` had, so unknown or newer options don't trigger excess property errors.
- `StripEnums` is removed — it was never exported from `src/index.ts`.
- `maxNodeModuleJsDepth` is now `number | undefined` rather than `any` (the `// TODO` in the type test anticipated this).

Side benefit: the published `.d.ts` no longer references `typescript`, so consumers don't need it installed to use `TSConfig`.

🤖 Generated with AI assistant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated TypeScript configuration handling with locally defined option types.
  - Added support for recognizing a broader range of compiler and type acquisition settings.
  - Improved compatibility with unknown or newly introduced TypeScript configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->